### PR TITLE
Fail on issues with dereferencing

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -22,7 +22,7 @@ export interface ResponseMeta {
 }
 
 export default function compile(oas: OpenAPIObject): CompiledPath[] {
-  const document: OpenAPIObject = deref(oas);
+  const document: OpenAPIObject = deref(oas, {failOnMissing: true});
 
   return Object.keys(document.paths).map((path: string) => {
     const pathItemObject: PathItemObject = document.paths[path];


### PR DESCRIPTION
Currently deref silently swallows the errors which causes a massive issue with ajv which crashes node on trying to parse non-resolved $refs.