### PR TITLE
add openapi3-middleware to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 If you are looking for framework specific middleware, you might want to look at following libraries that use oas3-chow-chow under the hood.
 
 [koa-oas3](https://github.com/supertong/koa-oas3)
+[openapi3-middleware](https://github.com/naugtur/openapi3-middleware)
 
 ## Installation
 


### PR DESCRIPTION
openapi3-middleware is a brand new project, but soon-to-be-used in 2 production apps in my team.
Feel free to wait with merging this for a while if you don't want to link to it yet.