### PR TITLE
Properly fail on issues with dereferencing

### DIFF
--- a/__test__/deref-error.spec.ts
+++ b/__test__/deref-error.spec.ts
@@ -1,0 +1,11 @@
+import ChowChow from '../src';
+import ChowError, { ResponseValidationError } from '../src/error';
+import {ResponseMeta} from '../src/compiler';
+
+const fixture = require('./fixtures/deref-error.json');
+
+describe('Deref Error', () => {
+  it('should throw a proper error', () => {
+    expect(() => new ChowChow(fixture)).toThrow('Missing $ref: #/components/schemas/blahBlahBlah');
+  });
+});

--- a/__test__/fixtures/deref-error.json
+++ b/__test__/fixtures/deref-error.json
@@ -1,0 +1,52 @@
+{
+	"openapi": "3.0.2",
+	"info": {
+		"version": "1.0.0",
+		"title": "Chow chow test",
+		"description": "test",
+		"contact": {
+			"name": "test",
+			"email": "test@test.com",
+			"url": "http://test.com"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+		}
+	},
+	"servers": [
+		{
+			"url": "http://test.com",
+			"description": "test"
+		}
+	],
+	"paths": {
+		"/v1/test": {
+			"get": {
+				"description": "test",
+				"operationId": "test",
+				"responses": {
+					"200": {
+						"$ref": "#/components/schemas/TestSchema"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"TestSchema": {
+				"description": "test",
+				"type": "object",
+				"properties": {
+					"test": {
+						"type": {
+							"$ref": "#/components/schemas/blahBlahBlah"
+						},
+						"description": "test"
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -25,6 +25,10 @@ export interface ResponseMeta {
 export default function compile(oas: OpenAPIObject, options: Partial<ChowOptions>): CompiledPath[] {
   const document: OpenAPIObject = deref(oas, {failOnMissing: true});
 
+  if (document instanceof Error){ 
+    throw document;
+  }
+
   return Object.keys(document.paths).map((path: string) => {
     const pathItemObject: PathItemObject = document.paths[path];
 


### PR DESCRIPTION
This [PR](https://github.com/atlassian/oas3-chow-chow/pull/13) addressed the issue of swallowing errors, but introduced an issue where this codebase was not properly erroring out.

I created a sample gist [here](https://gist.github.com/joeyjiron06/57e2492952859738a8768726e3d165b0) with a more detailed explanation of the issue.

**TLDR**
Currently the library is throwing `"TypeError: Cannot convert undefined or null to object"` when it should be throwing `"Missing $ref: #/components/schemas/blahBlahBlah"`



**Test output**

```bash
 PASS  __test__/chow-error.spec.ts
 PASS  __test__/deref-error.spec.ts
 PASS  __test__/query.spec.ts
 PASS  __test__/path.spec.ts
 PASS  __test__/response.spec.ts
 PASS  __test__/pet-store.spec.ts
-----------------------------|----------|----------|----------|----------|-------------------|
File                         |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------------------|----------|----------|----------|----------|-------------------|
All files                    |    98.94 |     95.5 |      100 |    98.93 |                   |
 src                         |    94.12 |    81.82 |      100 |    93.55 |                   |
  error.ts                   |      100 |      100 |      100 |      100 |                   |
  index.ts                   |       92 |    71.43 |      100 |    90.91 |             36,49 |
 src/compiler                |     99.6 |       97 |      100 |     99.6 |                   |
  CompiledMediaType.ts       |      100 |      100 |      100 |      100 |                   |
  CompiledOperation.ts       |      100 |      100 |      100 |      100 |                   |
  CompiledParameterCookie.ts |      100 |      100 |      100 |      100 |                   |
  CompiledParameterHeader.ts |      100 |      100 |      100 |      100 |                   |
  CompiledParameterPath.ts   |      100 |       75 |      100 |      100 |                28 |
  CompiledParameterQuery.ts  |      100 |    88.89 |      100 |      100 |                28 |
  CompiledPath.ts            |      100 |      100 |      100 |      100 |                   |
  CompiledPathItem.ts        |      100 |      100 |      100 |      100 |                   |
  CompiledRequestBody.ts     |      100 |      100 |      100 |      100 |                   |
  CompiledResponse.ts        |      100 |      100 |      100 |      100 |                   |
  CompiledResponseHeader.ts  |      100 |      100 |      100 |      100 |                   |
  CompiledSchema.ts          |    94.44 |    91.67 |      100 |    94.44 |                40 |
  ajv.ts                     |      100 |      100 |      100 |      100 |                   |
  index.ts                   |      100 |      100 |      100 |      100 |                   |
-----------------------------|----------|----------|----------|----------|-------------------|

Test Suites: 6 passed, 6 total
Tests:       48 passed, 48 total
Snapshots:   2 passed, 2 total
Time:        3.213s
Ran all test suites.
```

