### PR TITLE
allow to return defined body content type

### DIFF
--- a/__test__/__snapshots__/pet-store.spec.ts.snap
+++ b/__test__/__snapshots__/pet-store.spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pet Store RequestBody It returns defined body content type 1`] = `
+Array [
+  "application/json",
+]
+`;
+
+exports[`Pet Store RequestBody It returns empty array for defined body content type if method is undefined 1`] = `Array []`;
+
+exports[`Pet Store RequestBody It returns empty array for defined body content type if path is undefined 1`] = `Array []`;
+
+exports[`Pet Store RequestBody It returns empty array for defined body content type if requestBody is not defined 1`] = `Array []`;

--- a/__test__/pet-store.spec.ts
+++ b/__test__/pet-store.spec.ts
@@ -212,6 +212,33 @@ describe('Pet Store', () => {
         })
       }).toThrow(RequestValidationError)
     })
+
+    test('It returns defined body content type', () => {
+      expect(chowchow.getDefinedBodyContentType('/pets', 'post'))
+        .toMatchInlineSnapshot(`
+Array [
+  "application/json",
+]
+`);
+    })
+
+    test('It return empty array for defined body content type if path is undefined', () => {
+      expect(
+        chowchow.getDefinedBodyContentType('/nonono', 'post')
+      ).toMatchInlineSnapshot(`Array []`)
+    })
+
+    test('It return empty array for defined body content type if method is undefined', () => {
+      expect(
+        chowchow.getDefinedBodyContentType('/pets', 'head')
+      ).toMatchInlineSnapshot(`Array []`)
+    })
+
+    test('It return empty array for defined body content type if requestBody is not defined', () => {
+      expect(
+        chowchow.getDefinedBodyContentType('/pets', 'get')
+      ).toMatchInlineSnapshot(`Array []`)
+    })
   })
 
   describe('Header', () => {

--- a/__test__/pet-store.spec.ts
+++ b/__test__/pet-store.spec.ts
@@ -214,30 +214,26 @@ describe('Pet Store', () => {
     })
 
     test('It returns defined body content type', () => {
-      expect(chowchow.getDefinedBodyContentType('/pets', 'post'))
-        .toMatchInlineSnapshot(`
-Array [
-  "application/json",
-]
-`);
+      expect(chowchow.getDefinedRequestBodyContentType('/pets', 'post'))
+        .toMatchSnapshot();
     })
 
-    test('It return empty array for defined body content type if path is undefined', () => {
+    test('It returns empty array for defined body content type if path is undefined', () => {
       expect(
-        chowchow.getDefinedBodyContentType('/nonono', 'post')
-      ).toMatchInlineSnapshot(`Array []`)
+        chowchow.getDefinedRequestBodyContentType('/nonono', 'post')
+      ).toMatchSnapshot()
     })
 
-    test('It return empty array for defined body content type if method is undefined', () => {
+    test('It returns empty array for defined body content type if method is undefined', () => {
       expect(
-        chowchow.getDefinedBodyContentType('/pets', 'head')
-      ).toMatchInlineSnapshot(`Array []`)
+        chowchow.getDefinedRequestBodyContentType('/pets', 'head')
+      ).toMatchSnapshot()
     })
 
-    test('It return empty array for defined body content type if requestBody is not defined', () => {
+    test('It returns empty array for defined body content type if requestBody is not defined', () => {
       expect(
-        chowchow.getDefinedBodyContentType('/pets', 'get')
-      ).toMatchInlineSnapshot(`Array []`)
+        chowchow.getDefinedRequestBodyContentType('/pets', 'get')
+      ).toMatchSnapshot()
     })
   })
 

--- a/src/compiler/CompiledOperation.ts
+++ b/src/compiler/CompiledOperation.ts
@@ -60,7 +60,7 @@ export default class CompiledOperation {
     }, {});
   }
 
-  public getDefinedBodyContentType() {
+  public getDefinedRequestBodyContentType(): string[] {
     return this.body ? this.body.getDefinedContentTypes() : [];
   }
 

--- a/src/compiler/CompiledOperation.ts
+++ b/src/compiler/CompiledOperation.ts
@@ -60,6 +60,10 @@ export default class CompiledOperation {
     }, {});
   }
 
+  public getDefinedBodyContentType() {
+    return this.body ? this.body.getDefinedContentTypes() : [];
+  }
+
   public validateRequest(request: RequestMeta): RequestMeta {
     const header = this.compiledHeader.validate(request.header);
     const query = this.compiledQuery.validate(request.query);

--- a/src/compiler/CompiledPath.ts
+++ b/src/compiler/CompiledPath.ts
@@ -25,6 +25,10 @@ export default class CompiledPath {
     this.compiledPathItem = new CompiledPathItem(pathItemObject, path, options);
   }
 
+  public getDefinedBodyContentType(method: string) {
+    return this.compiledPathItem.getDefinedBodyContentType(method);
+  }
+
   public test(path: string): boolean {
     return XRegExp.test(path, this.regex);
   }

--- a/src/compiler/CompiledPath.ts
+++ b/src/compiler/CompiledPath.ts
@@ -25,8 +25,8 @@ export default class CompiledPath {
     this.compiledPathItem = new CompiledPathItem(pathItemObject, path, options);
   }
 
-  public getDefinedBodyContentType(method: string) {
-    return this.compiledPathItem.getDefinedBodyContentType(method);
+  public getDefinedRequestBodyContentType(method: string): string[] {
+    return this.compiledPathItem.getDefinedRequestBodyContentType(method);
   }
 
   public test(path: string): boolean {

--- a/src/compiler/CompiledPathItem.ts
+++ b/src/compiler/CompiledPathItem.ts
@@ -22,6 +22,10 @@ export default class CompiledPathItem {
     this.path = path;
   }
 
+  public getDefinedBodyContentType(method: string) {
+    return this.compiledOperations[method] ? this.compiledOperations[method].getDefinedBodyContentType() : [];
+  }
+
   public validateRequest(request: RequestMeta) {
     const method = request.method.toLowerCase();
     const compiledOperation = this.compiledOperations[method];

--- a/src/compiler/CompiledPathItem.ts
+++ b/src/compiler/CompiledPathItem.ts
@@ -22,8 +22,8 @@ export default class CompiledPathItem {
     this.path = path;
   }
 
-  public getDefinedBodyContentType(method: string) {
-    return this.compiledOperations[method] ? this.compiledOperations[method].getDefinedBodyContentType() : [];
+  public getDefinedRequestBodyContentType(method: string): string[] {
+    return this.compiledOperations[method] ? this.compiledOperations[method].getDefinedRequestBodyContentType() : [];
   }
 
   public validateRequest(request: RequestMeta) {

--- a/src/compiler/CompiledRequestBody.ts
+++ b/src/compiler/CompiledRequestBody.ts
@@ -44,6 +44,10 @@ export default class CompiledRequestBody {
     }
   }
 
+  public getDefinedContentTypes(): string[] {
+    return Object.keys(this.compiledSchemas).filter(type => this.compiledSchemas.hasOwnProperty(type));
+  }
+
   private findCompiledSchema(mediaType: string | undefined): CompiledSchema | undefined {
     if (!mediaType) {
       mediaType = '*/*';

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,10 +51,10 @@ export default class ChowChow {
     }
   }
 
-  getDefinedBodyContentType(path: string, method: string) {
+  getDefinedRequestBodyContentType(path: string, method: string) {
     try {
       const compiledPath = this.identifyCompiledPath(path);
-      return compiledPath.getDefinedBodyContentType(method);
+      return compiledPath.getDefinedRequestBodyContentType(method);
     } catch(err) {
       if (err instanceof ChowError) {
         return [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,19 @@ export default class ChowChow {
     }
   }
 
+  getDefinedBodyContentType(path: string, method: string) {
+    try {
+      const compiledPath = this.identifyCompiledPath(path);
+      return compiledPath.getDefinedBodyContentType(method);
+    } catch(err) {
+      if (err instanceof ChowError) {
+        return [];
+      } else {
+        throw err;
+      }
+    }
+  }
+
   private identifyCompiledPath(path: string) {
     const compiledPath = this.compiledPaths.find((cp: CompiledPath) => {
       return cp.test(path);


### PR DESCRIPTION
The purpose of this change is to allow upstream libraries to know what content type is defined in the schema so that they can decide what to do with the request body.


/cc @vvvlasov @lukiano 