### PR TITLE
Make HTTP header names case-insensitive

### DIFF
--- a/.changeset/three-cycles-deny.md
+++ b/.changeset/three-cycles-deny.md
@@ -1,0 +1,5 @@
+---
+"oas3-chow-chow": patch
+---
+
+Make HTTP header names case-insensitive

--- a/src/compiler/CompiledParameterHeader.ts
+++ b/src/compiler/CompiledParameterHeader.ts
@@ -16,18 +16,19 @@ export default class CompiledParameterHeader {
    * If in is "header" and the name field is "Accept", "Content-Type" or "Authorization",
    * the parameter definition SHALL be ignored.
    */
-  private ignoreHeaders = ['Accept', 'Content-Type', 'Authorization'];
+  private ignoreHeaders = ['Accept', 'Content-Type', 'Authorization'].map(header => header.toLowerCase())
 
   constructor(parameters: ParameterObject[], options: Partial<ChowOptions>) {
     for (const parameter of parameters) {
-      if (this.ignoreHeaders.includes(parameter.name)) {
+      const headerName = parameter.name.toLowerCase()
+      if (this.ignoreHeaders.includes(headerName)) {
         continue;
       }
 
-      this.headerSchema.properties![parameter.name] = parameter.schema || {};
+      this.headerSchema.properties![headerName] = parameter.schema || {};
 
       if (parameter.required) {
-        this.headerSchema.required!.push(parameter.name);
+        this.headerSchema.required!.push(headerName);
       }
     }
 


### PR DESCRIPTION
RFC 2616 specifies HTTP header names as case-insensitive. Thus,
lower-case the names we get from the schema.

Node's HTTP library does the same for incoming header names, so we don't
need to do anything there.