### PR TITLE
Upgrade `json-schema-deref-sync`

### DIFF
--- a/.changeset/smooth-cars-raise.md
+++ b/.changeset/smooth-cars-raise.md
@@ -1,0 +1,5 @@
+---
+"oas3-chow-chow": patch
+---
+
+Upgrade json-schema-deref-sync

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "ajv": "^6.10.2",
     "better-ajv-errors": "^0.6.7",
-    "json-schema-deref-sync": "^0.10.1",
+    "json-schema-deref-sync": "^0.13.0",
     "openapi3-ts": "^1.3.0",
     "xregexp": "^4.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2751,10 +2751,10 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-schema-deref-sync@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/json-schema-deref-sync/-/json-schema-deref-sync-0.10.1.tgz#a3a61ffb571b42c98584eaf209e0bb30318bb053"
-  integrity sha512-ESkdgGyLg5H0el8VvLe3ss8ANsRH05dPOG19HQ2T4hWG/rD1N6Iei7Xltc8Wwcz4pqc+mGWihP2d4mFWtk7A3A==
+json-schema-deref-sync@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz#cb08b4ff435a48b5a149652d7750fdd071009823"
+  integrity sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==
   dependencies:
     clone "^2.1.2"
     dag-map "~1.0.0"


### PR DESCRIPTION
There were plenty of fixes along the way, for example fixed file
reference support (which I *think* might still be broken when using
`oas3-chow-chow`, but that's a story for another PR).

(The most recent release of `json-schema-deref-sync` on GitHub is
0.12.0, but I believe that to be a simple publishing mistake. See
cvent/json-schema-deref-sync#35).