### PR TITLE
Fix types and docs

### DIFF
--- a/.changeset/brave-kiwis-tickle.md
+++ b/.changeset/brave-kiwis-tickle.md
@@ -1,0 +1,5 @@
+---
+"oas3-chow-chow": minor
+---
+
+Fixed type of ChowError.meta.rawErrors and updated documentation

--- a/README.md
+++ b/README.md
@@ -30,22 +30,21 @@ import * as yaml from "js-yaml";
 var doc = yaml.safeLoad(fs.readFileSync("./openapi.yml", "utf8"));
 const chow = new ChowChow(doc);
 
-chow.validateRequest("./books", {
-  method: "post",
-  query: {
-    expand: ["document", "author"]
-  },
-  body: {
-    name: "a nice book",
-    author: "me me me"
+// For URL: /:pathParam/info?arrParam=x&arrParam=y&other=z
+chow.validateRequestByPath(
+  // url.pathname,
+  "/books/info",
+  "POST", {
+    path: { pathParam: "books" },
+    // query: querystring.parse(url.search.substr(1)),
+    query: { arrParam: ["x", "y"], other: "z" },
+    // header: req.headers,
+    header: { "Content-Type": "application/json" },
+    body: { a: 1, b: 2 },
   }
-});
-
-chow.validateResponse("./books", {
-  method: "post",
-  header: {
-    "content-type": "application/json"
-  },
+);
+chow.validateResponseByPath("/books/info", "POST", {
+  header: { "Content-Type": "application/json" },
   body: {
     name: "a nice book",
     author: "me me me"

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,8 @@
+import * as betterAjvErrors from 'better-ajv-errors';
+
 export interface ChowErrorMeta {
   in: string;
-  rawErrors?: string[];
+  rawErrors?: betterAjvErrors.IOutputError[];
   code?: number;
 }
 


### PR DESCRIPTION
Fixes the type of `ChowError.meta.rawErrors` and updates the README to use the new non-deprecated API with some more concrete examples (the types of a lot of the arguments are `any` which makes it hard to know what is valid there).