### PR TITLE
fix: use responseBodyAjvOptions if passed

### DIFF
--- a/.changeset/good-seals-fry.md
+++ b/.changeset/good-seals-fry.md
@@ -1,0 +1,5 @@
+---
+"oas3-chow-chow": patch
+---
+
+fix: use responseBodyAjvOptions if passed

--- a/__test__/fixtures/option-unknown-fmt.json
+++ b/__test__/fixtures/option-unknown-fmt.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Option Body Fixture",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "format": "pet-name"
+          }
+        }
+      }
+    }
+  }
+}

--- a/__test__/option.spec.ts
+++ b/__test__/option.spec.ts
@@ -1,0 +1,20 @@
+
+import ChowChow from '../src';
+
+describe('Option Body', () => {
+  it('throw with unknown format', () => {
+    const fixture = require('./fixtures/option-unknown-fmt.json');
+
+    expect(() => {
+      new ChowChow(fixture);
+    }).toThrow('unknown format "pet-name" is used in schema at path "#/properties/name"');
+  })
+
+  it('success with unknown format if unknown format is allowed', () => {
+    const fixture = require('./fixtures/option-unknown-fmt.json');
+
+    expect(() => {
+      new ChowChow(fixture, { responseBodyAjvOptions: { unknownFormats: 'ignore' } });
+    }).not.toThrow();
+  })
+})

--- a/src/compiler/CompiledMediaType.ts
+++ b/src/compiler/CompiledMediaType.ts
@@ -1,4 +1,5 @@
 import { MediaTypeObject } from 'openapi3-ts';
+import * as Ajv from 'ajv';
 import CompiledSchema from './CompiledSchema';
 import ChowError from '../error';
 
@@ -6,10 +7,10 @@ export default class CompiledMediaType {
   private name: string;
   private compiledSchema: CompiledSchema;
 
-  constructor(name: string, mediaType: MediaTypeObject) {
+  constructor(name: string, mediaType: MediaTypeObject, opts?: Ajv.Options) {
     this.name = name;
     this.compiledSchema = new CompiledSchema(mediaType.schema || {},
-      {},
+      opts || {},
       { schemaContext: 'response' });
   }
 

--- a/src/compiler/CompiledOperation.ts
+++ b/src/compiler/CompiledOperation.ts
@@ -55,7 +55,7 @@ export default class CompiledOperation {
     this.operationId = operation.operationId;
 
     this.response = Object.keys(operation.responses).reduce((compiled: any, status: string) => {
-      compiled[status] = new CompiledResponse(operation.responses[status]);
+      compiled[status] = new CompiledResponse(operation.responses[status], options);
       return compiled;
     }, {});
   }

--- a/src/compiler/CompiledResponse.ts
+++ b/src/compiler/CompiledResponse.ts
@@ -3,6 +3,7 @@ import ChowError from '../error';
 import CompiledResponseHeader from './CompiledResponseHeader';
 import { ResponseMeta } from '.';
 import CompiledMediaType from './CompiledMediaType';
+import { ChowOptions } from '..';
 
 export default class CompiledResponse {
   private compiledResponseHeader: CompiledResponseHeader;
@@ -10,12 +11,12 @@ export default class CompiledResponse {
     [key: string]: CompiledMediaType
   } = {};
 
-  constructor(response: ResponseObject) {
-    this.compiledResponseHeader = new CompiledResponseHeader(response.headers);
+  constructor(response: ResponseObject, options: Partial<ChowOptions>) {
+    this.compiledResponseHeader = new CompiledResponseHeader(response.headers, options);
 
     if (response.content) {
       this.content = Object.keys(response.content).reduce((compiled: any, name: string) => {
-        compiled[name] = new CompiledMediaType(name, response.content![name] as MediaTypeObject);
+        compiled[name] = new CompiledMediaType(name, response.content![name] as MediaTypeObject, options.responseBodyAjvOptions || {});
         return compiled;
       }, {});
     }

--- a/src/compiler/CompiledResponseHeader.ts
+++ b/src/compiler/CompiledResponseHeader.ts
@@ -1,6 +1,7 @@
 import { HeadersObject, SchemaObject, HeaderObject } from 'openapi3-ts';
 import CompiledSchema from './CompiledSchema';
 import ChowError from '../error';
+import { ChowOptions } from '..';
 
 export default class CompiledResponseHeader {
   private compiledSchema: CompiledSchema;
@@ -14,7 +15,7 @@ export default class CompiledResponseHeader {
    */
   private ignoreHeaders = ['Content-Type'];
 
-  constructor(headers: HeadersObject = {}) {
+  constructor(headers: HeadersObject = {}, options: Partial<ChowOptions>) {
     for (const name in headers) {
       if (this.ignoreHeaders.includes(name)) {
         continue;
@@ -29,7 +30,7 @@ export default class CompiledResponseHeader {
         this.headerSchema.required!.push(name);
       }
     }
-    this.compiledSchema = new CompiledSchema(this.headerSchema);
+    this.compiledSchema = new CompiledSchema(this.headerSchema, options.headerAjvOptions || {});
   }
 
   public validate(value: any = {}) {


### PR DESCRIPTION
After this PR is merged, I'll submit another PR which formats all codes using prettier.