### PR TITLE
Handle additional OAS keywords

### DIFF
--- a/.changeset/eighty-falcons-refuse.md
+++ b/.changeset/eighty-falcons-refuse.md
@@ -1,0 +1,5 @@
+---
+'oas3-chow-chow': patch
+---
+
+log all strict mode errors in ajv

--- a/.changeset/eighty-falcons-refuse.md
+++ b/.changeset/eighty-falcons-refuse.md
@@ -2,4 +2,4 @@
 'oas3-chow-chow': patch
 ---
 
-log all strict mode errors in ajv
+handle additional open api keywords

--- a/__test__/chow-keywords.spec.ts
+++ b/__test__/chow-keywords.spec.ts
@@ -1,6 +1,8 @@
-import { OpenAPIObject, PathItemObject } from 'openapi3-ts';
+import { OpenAPIObject } from 'openapi3-ts';
 import ChowChow from '../src';
-const doc: OpenAPIObject = {
+const doc: (additionalKeywords: Record<string, any>) => OpenAPIObject = (
+  additionalKeywords = {}
+) => ({
   openapi: '3.0.1',
   info: {
     title: 'Object Resolver Service open api spec',
@@ -10,31 +12,10 @@ const doc: OpenAPIObject = {
     schemas: {
       ResolveUnsupportedError: {
         type: 'object',
-        description:
-          'This error is thrown when a request for a unsupported url is made in the resolve path (check path will just return unsupported)',
-        example:
-          '{error: {type: "ResolveUnsupportedError", message: "Invalid URL when trying to parse url", status: 404}}',
-        required: ['error'],
-        additionalProperties: false,
         properties: {
-          error: {
-            type: 'object',
-            required: ['message', 'type', 'status'],
-            additionalProperties: false,
-            properties: {
-              type: {
-                type: 'string',
-              },
-              message: {
-                type: 'string',
-              },
-              status: {
-                type: 'integer',
-                default: 404,
-              },
-            },
-          },
+          error: {},
         },
+        ...additionalKeywords,
       },
     },
   },
@@ -42,11 +23,8 @@ const doc: OpenAPIObject = {
     '/resolve': {
       post: {
         operationId: 'resolve',
-        description: 'Resolve an URL into a Object model.',
-        tags: ['Resolving URLs into JSON-LD'],
         responses: {
           '404': {
-            description: 'This URL is not supported by any objectProvider',
             content: {
               'application/json': {
                 schema: {
@@ -59,11 +37,19 @@ const doc: OpenAPIObject = {
       },
     },
   },
-};
-describe('keywords', () => {
-  // OpenAPI schemas can also use keywords that are not part of JSON Schema
-  // see "Additional Keywords" section in https://swagger.io/docs/specification/data-models/keywords/
-  it('"example" keyword should be allowed', () => {
-    expect(ChowChow.create(doc)).toBeDefined();
+});
+/**
+ * OpenAPI schemas can also use keywords that are not part of JSON Schema
+ * see "Additional Keywords" section in https://swagger.io/docs/specification/data-models/keywords/
+ * S
+ */
+describe('additional keywords', () => {
+  it.each([
+    { discriminator: '' },
+    { example: '' },
+    { externalDocs: '' },
+    { xml: '' },
+  ])('"%s" keyword should be allowed by default', async (additionalKeyword) => {
+    expect(await ChowChow.create(doc(additionalKeyword))).toBeDefined();
   });
 });

--- a/__test__/chow-keywords.spec.ts
+++ b/__test__/chow-keywords.spec.ts
@@ -38,12 +38,8 @@ const doc: (additionalKeywords: Record<string, any>) => OpenAPIObject = (
     },
   },
 });
-/**
- * OpenAPI schemas can also use keywords that are not part of JSON Schema
- * see "Additional Keywords" section in https://swagger.io/docs/specification/data-models/keywords/
- * S
- */
-describe('additional keywords', () => {
+
+describe('additional open api keywords', () => {
   it.each([
     { discriminator: '' },
     { example: '' },

--- a/__test__/chow-keywords.spec.ts
+++ b/__test__/chow-keywords.spec.ts
@@ -1,0 +1,69 @@
+import { OpenAPIObject, PathItemObject } from 'openapi3-ts';
+import ChowChow from '../src';
+const doc: OpenAPIObject = {
+  openapi: '3.0.1',
+  info: {
+    title: 'Object Resolver Service open api spec',
+    version: '1.0.1',
+  },
+  components: {
+    schemas: {
+      ResolveUnsupportedError: {
+        type: 'object',
+        description:
+          'This error is thrown when a request for a unsupported url is made in the resolve path (check path will just return unsupported)',
+        example:
+          '{error: {type: "ResolveUnsupportedError", message: "Invalid URL when trying to parse url", status: 404}}',
+        required: ['error'],
+        additionalProperties: false,
+        properties: {
+          error: {
+            type: 'object',
+            required: ['message', 'type', 'status'],
+            additionalProperties: false,
+            properties: {
+              type: {
+                type: 'string',
+              },
+              message: {
+                type: 'string',
+              },
+              status: {
+                type: 'integer',
+                default: 404,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  paths: {
+    '/resolve': {
+      post: {
+        operationId: 'resolve',
+        description: 'Resolve an URL into a Object model.',
+        tags: ['Resolving URLs into JSON-LD'],
+        responses: {
+          '404': {
+            description: 'This URL is not supported by any objectProvider',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ResolveUnsupportedError',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+describe('keywords', () => {
+  // OpenAPI schemas can also use keywords that are not part of JSON Schema
+  // see "Additional Keywords" section in https://swagger.io/docs/specification/data-models/keywords/
+  it('"example" keyword should be allowed', () => {
+    expect(ChowChow.create(doc)).toBeDefined();
+  });
+});

--- a/__test__/chow-keywords.spec.ts
+++ b/__test__/chow-keywords.spec.ts
@@ -5,7 +5,7 @@ const doc: (additionalKeywords: Record<string, any>) => OpenAPIObject = (
 ) => ({
   openapi: '3.0.1',
   info: {
-    title: 'Object Resolver Service open api spec',
+    title: 'service open api spec',
     version: '1.0.1',
   },
   components: {

--- a/__test__/chow-strict.spec.ts
+++ b/__test__/chow-strict.spec.ts
@@ -10,7 +10,7 @@ describe('strict mode', () => {
     const doc: OpenAPIObject = {
       openapi: '3.0.1',
       info: {
-        title: 'Object Resolver Service open api spec',
+        title: 'service open api spec',
         version: '1.0.1',
       },
       components: {

--- a/__test__/chow-strict.spec.ts
+++ b/__test__/chow-strict.spec.ts
@@ -1,0 +1,49 @@
+import { OpenAPIObject, PathItemObject } from 'openapi3-ts';
+import ChowChow from '../src';
+
+/**
+ * https://ajv.js.org/strict-mode.html
+ */
+describe('strict mode', () => {
+  it('show log warn and not throw by default', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const doc: OpenAPIObject = {
+      openapi: '3.0.1',
+      info: {
+        title: 'Object Resolver Service open api spec',
+        version: '1.0.1',
+      },
+      components: {
+        schemas: {
+          ResolveUnsupportedError: {
+            type: 'array',
+            additionalItems: false,
+          },
+        },
+      },
+      paths: {
+        '/resolve': {
+          post: {
+            operationId: 'resolve',
+            responses: {
+              '404': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResolveUnsupportedError',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(await ChowChow.create(doc)).toBeDefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'strict mode: "additionalItems" is ignored when "items" is not an array of schemas'
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/src/compiler/CompiledSchema.ts
+++ b/src/compiler/CompiledSchema.ts
@@ -10,9 +10,8 @@ export default class CompiledSchema {
   constructor(schema: SchemaObject, opts?: Ajv.Options, context?: any) {
     /**
      * Remove unsupported additional OpenAPI keywords.
-     * https://swagger.io/docs/specification/data-models/keywords/
-     * See "Additional Keywords"
-     * Does not include all keywords listed in that links because some of them are supported by ajv https://ajv.js.org/json-schema.html#openapi-support
+     * https://swagger.io/docs/specification/data-models/keywords/ See "Additional Keywords"
+     * Does not include all keywords listed in that page/section because some of them are supported by ajv https://ajv.js.org/json-schema.html#openapi-support
      * and some are explictly added within this class.
      */
     const {

--- a/src/compiler/CompiledSchema.ts
+++ b/src/compiler/CompiledSchema.ts
@@ -31,7 +31,6 @@ export default class CompiledSchema {
       validate: (schema: any) =>
         schema ? context.schemaContext === 'request' : true,
     });
-    ajvInstance.getKeyword;
     ajvInstance.addKeyword({
       keyword: 'readOnly',
       validate: (schema: any) =>

--- a/src/compiler/CompiledSchema.ts
+++ b/src/compiler/CompiledSchema.ts
@@ -9,7 +9,7 @@ export default class CompiledSchema {
 
   constructor(schema: SchemaObject, opts?: Ajv.Options, context?: any) {
     /**
-     * Removing unsupported additional OpenAPI keywords.
+     * Remove unsupported additional OpenAPI keywords.
      * https://swagger.io/docs/specification/data-models/keywords/
      * See "Additional Keywords"
      * Does not include all keywords listed in that links because some of them are supported by ajv https://ajv.js.org/json-schema.html#openapi-support

--- a/src/compiler/CompiledSchema.ts
+++ b/src/compiler/CompiledSchema.ts
@@ -8,7 +8,22 @@ export default class CompiledSchema {
   private validator: Ajv.ValidateFunction;
 
   constructor(schema: SchemaObject, opts?: Ajv.Options, context?: any) {
-    this.schemaObject = schema;
+    /**
+     * Removing unsupported additional OpenAPI keywords.
+     * https://swagger.io/docs/specification/data-models/keywords/
+     * See "Additional Keywords"
+     * Does not include all keywords listed in that links because some of them are supported by ajv https://ajv.js.org/json-schema.html#openapi-support
+     * and some are explictly added within this class.
+     */
+    const {
+      discriminator,
+      example,
+      externalDocs,
+      xml,
+      ...schemaObject
+    } = schema;
+    this.schemaObject = schemaObject;
+
     const ajvInstance = ajv(opts);
     ajvInstance.removeKeyword('writeOnly');
     ajvInstance.removeKeyword('readOnly');
@@ -17,14 +32,14 @@ export default class CompiledSchema {
       validate: (schema: any) =>
         schema ? context.schemaContext === 'request' : true,
     });
+    ajvInstance.getKeyword;
     ajvInstance.addKeyword({
       keyword: 'readOnly',
       validate: (schema: any) =>
         schema ? context.schemaContext === 'response' : true,
     });
-    this.validator = ajvInstance.compile(schema);
+    this.validator = ajvInstance.compile(schemaObject);
   }
-
   public validate(value: any) {
     const valid = this.validator(value);
     if (!valid) {

--- a/src/compiler/CompiledSchema.ts
+++ b/src/compiler/CompiledSchema.ts
@@ -38,6 +38,7 @@ export default class CompiledSchema {
     });
     this.validator = ajvInstance.compile(schemaObject);
   }
+
   public validate(value: any) {
     const valid = this.validator(value);
     if (!valid) {

--- a/src/compiler/ajv.ts
+++ b/src/compiler/ajv.ts
@@ -1,7 +1,7 @@
 import Ajv, { Options } from 'ajv';
 import addFormats from 'ajv-formats';
 
-const options: Options = {};
+const options: Options = { strict: 'log' };
 
 export default function ajv(opts: Options = {}) {
   const ajv = new Ajv({


### PR DESCRIPTION
This is to handle presence of open api keywords that are not part of the json schema.
- Remove them from the schema object before passing it down to ajv validator as it expects only a json schema instead of open api schema.
- Also turn strict mode to log instead of throwing as a backup so that we don't blow up if we miss any keywords.