### PR TITLE
Prevent example additional keyword from logging warning

### DIFF
--- a/.changeset/sharp-donuts-kneel.md
+++ b/.changeset/sharp-donuts-kneel.md
@@ -1,0 +1,5 @@
+---
+'oas3-chow-chow': patch
+---
+
+Prevent example keyword from causing warning logs when present in openapi spec

--- a/__test__/chow-strict.spec.ts
+++ b/__test__/chow-strict.spec.ts
@@ -46,4 +46,57 @@ describe('strict mode', () => {
     );
     warnSpy.mockRestore();
   });
+
+  it('should not log warning about example keyword', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const doc: OpenAPIObject = {
+      openapi: '3.0.1',
+      info: {
+        title: 'service open api spec',
+        version: '1.0.1',
+      },
+      components: {
+        schemas: {
+          ResolveUnsupportedError: {
+            type: 'object',
+            description: 'some description',
+            properties: {
+              error: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string',
+                    example: 'some example',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      paths: {
+        '/resolve': {
+          post: {
+            operationId: 'resolve',
+            responses: {
+              '404': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResolveUnsupportedError',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(await ChowChow.create(doc)).toBeDefined();
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      'strict mode: unknown keyword: "example"'
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/src/compiler/CompiledSchema.ts
+++ b/src/compiler/CompiledSchema.ts
@@ -36,6 +36,12 @@ export default class CompiledSchema {
       validate: (schema: any) =>
         schema ? context.schemaContext === 'response' : true,
     });
+    ajvInstance.addKeyword({
+      keyword: 'example',
+      metaSchema: {
+        type: ['object', 'array', 'string', 'number', 'boolean', 'null'],
+      },
+    });
     this.validator = ajvInstance.compile(schemaObject);
   }
 


### PR DESCRIPTION
The example keyword is an additional keyword which causes a warning to be logged when AJV strict mode is set to log. This results in a lot of logging which obfuscates investigations and debugging, and is not meaningful to be logged.

Fixes this by adding the `example` keyword to the AJV validator, and allowing it to pass through assuming it conforms to one of the meta schema types.